### PR TITLE
Fixing installation problem

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get -y update
 
 # install packages
 RUN apt-get -y --no-install-recommends --no-install-suggests install host socat unzip ca-certificates wget
-RUN apt-get -y install mariadb-galera-server galera mariadb-client xtrabackup
+RUN apt-get -y install mariadb-galera-server-10.0 galera-3 mariadb-client xtrabackup
 
 # install galera-healthcheck
 RUN wget -O /bin/galera-healthcheck 'https://github.com/sttts/galera-healthcheck/releases/download/v20150303/galera-healthcheck_linux_amd64'

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Compare ["MariaDB Galera on a Mesos Cluster with Docker"](http://sttts.github.io
 
 ```bash
 $ docker run -d -v /data:/var/lib/mysql -p 3306 -p 8080 \
-    -e XTRABACKUP_PASSWORD=abc -e MYSQL_PASSWORD=secret \
+    -e XTRABACKUP_PASSWORD=abc -e MYSQL_ROOT_PASSWORD=secret \
     sttts/galera-mariadb-10.0-xtrabackup seed
 
 $ docker run -d -v /data:/var/lib/mysql -p 3306 -p 8080 \


### PR DESCRIPTION
I tried to build the docker file, but I got the following:

<code>
The following packages have unmet dependencies:
 mariadb-galera-server : Depends: mariadb-galera-server-10.0 (= 10.0.17+maria-1~trusty) but it is not going to be installed
E: Unable to correct problems, you have held broken packages.
INFO[0011] The command [/bin/sh -c apt-get -y install mariadb-galera-server galera mariadb-client xtrabackup] returned a non-zero code: 100
</code>

Also in README.md, MYSQL_PASSWORD should be MYSQL_ROOT_PASSWORD 
